### PR TITLE
Add spinach.task.AbortException

### DIFF
--- a/doc/user/tasks.rst
+++ b/doc/user/tasks.rst
@@ -89,6 +89,10 @@ allows to precisely control when it should be retried::
 
 .. autoclass:: spinach.task.RetryException
 
+A task can also raise a :class:`AbortException` for short-circuit behavior::
+
+.. autoclass:: spinach.task.AbortException
+
 Periodic tasks
 --------------
 

--- a/spinach/__init__.py
+++ b/spinach/__init__.py
@@ -2,6 +2,6 @@ from .brokers.memory import MemoryBroker
 from .brokers.redis import RedisBroker
 from .const import VERSION
 from .engine import Engine
-from .task import Tasks, Batch, RetryException
+from .task import Tasks, Batch, RetryException, AbortException
 
 __version__ = VERSION

--- a/spinach/task.py
+++ b/spinach/task.py
@@ -280,3 +280,11 @@ class RetryException(Exception):
     def __init__(self, message, at: Optional[datetime]=None):
         super().__init__(message)
         self.at = at
+
+
+class AbortException(Exception):
+    """Exception raised in a task to indicate that the job should NOT be
+    retried.
+
+    If this exception is raised, all retry attempts are stopped immediately.
+    """

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from spinach import RetryException
+from spinach import RetryException, AbortException
 from spinach.job import Job, JobStatus, advance_job_status
 
 from .conftest import get_now, set_now
@@ -115,4 +115,10 @@ def test_advance_job_status(job):
     job.max_retries = 0
     advance_job_status('namespace', job, 1.0,
                        RetryException('Must retry', at=now))
+    assert job.status is JobStatus.FAILED
+
+    job.status = JobStatus.RUNNING
+    job.max_retries = 10
+    advance_job_status('namespace', job, 1.0, AbortException('kaboom'))
+    assert job.max_retries == 0
     assert job.status is JobStatus.FAILED


### PR DESCRIPTION
Add an exception to allow for retry jobs to short-circuit, e.g., for fatal error conditions in tasks where it is known they will never succeed and any further retries would be pointless