### PR TITLE
Add max_concurrency to tasks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,7 @@ Distinctive features:
 
 - At-least-once or at-most-once delivery per task
 - Periodic tasks without an additional process
+- Concurrency limits on queued jobs
 - Scheduling of tasks in batch
 - Integrations with `Flask, Django, Logging, Sentry and Datadog
   <https://spinach.readthedocs.io/en/stable/user/integrations.html>`_

--- a/doc/hacking/contributing.rst
+++ b/doc/hacking/contributing.rst
@@ -32,13 +32,23 @@ The code base follows `pep8 <https://www.python.org/dev/peps/pep-0008/>`_
 guidelines with lines wrapping at the 79th character. You can verify that the
 code follows the conventions with::
 
-    $ pep8 spinach tests
+    $ pycodestyle --ignore=E252,W503,W504 spinach tests
 
 Running tests is an invaluable help when adding a new feature or when
 refactoring. Try to add the proper test cases in ``tests/`` together with your
 patch. The test suite can be run with pytest::
 
     $ pytest tests
+
+Because the Redis broker tests require a running Redis server, there is also a
+convenience `tox.ini` that runs all the tests and pep8 checks for you after
+starting Redis in a container via docker-compose.  Simply running::
+
+    $ tox
+
+will build a virtualenv, install Spinach and its dependencies into it,
+start the Redis server in the container, and run tests and pycodestyle,
+tearing down the Redis server container when done.
 
 Compatibility
 -------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,6 +9,7 @@ Distinctive features:
 
 - At-least-once or at-most-once delivery per task
 - Periodic tasks without an additional process
+- Concurrency limits on queued jobs
 - Scheduling of tasks in batch
 - Embeddable workers for easier testing
 - Integrations with :ref:`Flask, Django, Logging, Sentry and Datadog

--- a/doc/user/tasks.rst
+++ b/doc/user/tasks.rst
@@ -109,6 +109,22 @@ A task can also raise a :class:`AbortException` for short-circuit behavior:
 
 .. autoclass:: spinach.task.AbortException
 
+Limiting task concurrency
+-------------------------
+
+If a task is idempotent it may also have a limit on the number of
+concurrent jobs spawned across all workers. These types of tasks are
+defined with a positive `max_concurrency` value::
+
+    @tasks.task(name='foo', max_retries=10, max_concurrency=1)
+    def foo(a, b):
+        pass
+
+With this definition, no more than one instance of the Task will ever be
+spawned as a running Job, no matter how many are queued and waiting to
+run.
+
+
 Periodic tasks
 --------------
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,9 @@ setup(
             'flush.lua',
             'get_jobs_from_queue.lua',
             'move_future_jobs.lua',
-            'register_periodic_tasks.lua'
+            'register_periodic_tasks.lua',
+            'remove_job_from_running.lua',
+            'set_concurrency_keys.lua',
         ],
     },
 )

--- a/spinach/brokers/base.py
+++ b/spinach/brokers/base.py
@@ -86,6 +86,18 @@ class Broker(ABC):
         """Register tasks that need to be scheduled periodically."""
 
     @abstractmethod
+    def set_concurrency_keys(self, tasks: Iterable[Task]):
+        """Register concurrency data for Tasks.
+
+        Set up anything in the Broker that is required to track
+        concurrency on Tasks, where a Task defines max_concurrency.
+        """
+
+    @abstractmethod
+    def is_queue_empty(self, queue: str) -> bool:
+        """Return True if the provided queue is empty."""
+
+    @abstractmethod
     def inspect_periodic_tasks(self) -> List[Tuple[int, str]]:
         """Get the next periodic task schedule.
 
@@ -93,7 +105,7 @@ class Broker(ABC):
         """
 
     @abstractmethod
-    def enqueue_jobs(self, jobs: Iterable[Job]):
+    def enqueue_jobs(self, jobs: Iterable[Job], from_failure: bool):
         """Enqueue a batch of jobs."""
 
     @abstractmethod

--- a/spinach/brokers/redis_scripts/enqueue_job.lua
+++ b/spinach/brokers/redis_scripts/enqueue_job.lua
@@ -4,16 +4,27 @@ local notifications = ARGV[2]
 local running_jobs_key = ARGV[3]
 local namespace = ARGV[4]
 local future_jobs = ARGV[5]
--- jobs starting at ARGV[6]
+local max_concurrency_key = ARGV[6]
+local current_concurrency_key = ARGV[7]
+local from_failure = ARGV[8]
+
+-- jobs starting at ARGV[9]
 
 if not redis.call('set', idempotency_token, 'true', 'EX', 3600, 'NX') then
     redis.log(redis.LOG_WARNING, "Not reprocessing script")
     return -1
 end
 
-for i=6, #ARGV do
+for i=9, #ARGV do
     local job_json = ARGV[i]
     local job = cjson.decode(job_json)
+    if tonumber(from_failure) == 1 then
+        -- job is being requeued after a failure, decrement its concurrency
+        local max_concurrency = tonumber(redis.call('hget', max_concurrency_key, job['task_name']))
+        if max_concurrency ~= nil and max_concurrency ~= -1 then
+            redis.call('hincrby', current_concurrency_key, job['task_name'], -1)
+        end
+    end
     if job["status"] == 2 then
         -- job status is queued
         local queue = string.format("%s/%s", namespace, job["queue"])

--- a/spinach/brokers/redis_scripts/get_jobs_from_queue.lua
+++ b/spinach/brokers/redis_scripts/get_jobs_from_queue.lua
@@ -2,27 +2,54 @@ local queue = ARGV[1]
 local running_jobs_key = ARGV[2]
 local job_status_running = tonumber(ARGV[3])
 local max_jobs = tonumber(ARGV[4])
+local max_concurrency_key = ARGV[5]
+local current_concurrency_key = ARGV[6]
 
 local jobs = {}
+local jobs_to_re_add = {}
+local num_jobs_to_re_add = 0
 
-for i=1, max_jobs do
+local i = 1
+repeat
 
     local job_json = redis.call('lpop', queue)
     if not job_json then
-        return cjson.encode(jobs)
+        break
     end
 
     local job = cjson.decode(job_json)
-    job["status"] = job_status_running
-    local job_json = cjson.encode(job)
+    local max_concurrency = tonumber(redis.call('hget', max_concurrency_key, job['task_name']))
+    local current_concurrency = tonumber(redis.call('hget', current_concurrency_key, job['task_name']))
 
-    if job["max_retries"] > 0 then
-        -- job is idempotent, must track if it's running
-        redis.call('hset', running_jobs_key, job["id"], job_json)
+    if max_concurrency ~= nil and max_concurrency ~= -1 and current_concurrency >= max_concurrency then
+        -- The max concurrency limit was reach on this Task, Re-add the
+        -- job(s) to the front of the queue after the loop finishes.
+        num_jobs_to_re_add = num_jobs_to_re_add + 1
+        jobs_to_re_add[num_jobs_to_re_add] = job_json
+    else
+        job["status"] = job_status_running
+        local job_json = cjson.encode(job)
+
+        if job["max_retries"] > 0 then
+            -- job is idempotent, must track if it's running
+            redis.call('hset', running_jobs_key, job["id"], job_json)
+            -- If tracking concurrency, bump the current value.
+            if max_concurrency ~= -1 then
+                redis.call('hincrby', current_concurrency_key, job['task_name'], 1)
+            end
+        end
+
+        jobs[i] = job_json
+        i = i + 1
     end
 
-    jobs[i] = job_json
+until i > max_jobs
 
+-- Re-add any jobs that were popped but could not be run due to
+-- max_concurrency limits. Loop in reverse order to keep the same
+-- original ordering!
+for i = #jobs_to_re_add, 1, -1 do
+    redis.call('lpush', queue, jobs_to_re_add[i])
 end
 
 return cjson.encode(jobs)

--- a/spinach/brokers/redis_scripts/remove_job_from_running.lua
+++ b/spinach/brokers/redis_scripts/remove_job_from_running.lua
@@ -1,0 +1,15 @@
+local running_jobs_key = ARGV[1]
+local max_concurrency_key = ARGV[2]
+local current_concurrency_key = ARGV[3]
+local job_json = ARGV[4]
+
+local job = cjson.decode(job_json)
+
+-- Remove the job from the list of running jobs.
+redis.call('hdel', running_jobs_key, job['id'])
+
+-- Decrement current concurrency if max concurrency set on the Task.
+local max_concurrency = tonumber(redis.call('hget', max_concurrency_key, job['task_name']))
+if max_concurrency ~= nil and max_concurrency ~= -1 then
+    redis.call('hincrby', current_concurrency_key, job['task_name'], -1)
+end

--- a/spinach/brokers/redis_scripts/set_concurrency_keys.lua
+++ b/spinach/brokers/redis_scripts/set_concurrency_keys.lua
@@ -1,0 +1,46 @@
+local max_concurrency_key = ARGV[1]
+local current_concurrency_key = ARGV[2]
+-- tasks to register starting at ARGV[3]
+
+
+local function contains(t, e)
+  return t[e]
+end
+
+local old_max_values = redis.call('hkeys', max_concurrency_key)
+local old_current_values = redis.call('hkeys', current_concurrency_key)
+
+local new_task_names = {}
+
+for i=3, #ARGV do
+    local task_json = ARGV[i]
+    local task = cjson.decode(task_json)
+    local max_concurrency = tonumber(task["max_concurrency"])
+    if max_concurrency ~= -1 then
+        new_task_names[task["name"]] = true
+
+        -- Override max_concurrency whatever it is already set to, if
+        -- anything.
+        redis.call('hset', max_concurrency_key, task["name"], max_concurrency)
+        -- Check to see if current_concurrency exists before initialising
+        -- it.
+        if redis.call('hexists', current_concurrency_key, task["name"]) == 0 then
+            redis.call('hset', current_concurrency_key, task["name"], 0)
+        end
+    end
+end
+
+-- Delete concurrency keys for Tasks that no longer exist.
+for i=1, #old_max_values do
+    local old_task_name = old_max_values[i]
+    if not contains(new_task_names, old_task_name) then
+        redis.call('hdel', max_concurrency_key, old_task_name)
+    end
+end
+
+for i=1, #old_current_values do
+    local old_task_name = old_current_values[i]
+    if not contains(new_task_names, old_task_name) then
+        redis.call('hdel', current_concurrency_key, old_task_name)
+    end
+end

--- a/spinach/const.py
+++ b/spinach/const.py
@@ -1,4 +1,4 @@
-VERSION = '0.0.13'
+VERSION = '0.0.14'
 
 DEFAULT_QUEUE = 'spinach'
 DEFAULT_NAMESPACE = 'spinach'
@@ -13,5 +13,7 @@ PERIODIC_TASKS_HASH_KEY = '_periodic_tasks_hash'
 PERIODIC_TASKS_QUEUE_KEY = '_periodic_tasks_queue'
 ALL_BROKERS_HASH_KEY = '_all_brokers_hash'
 ALL_BROKERS_ZSET_KEY = '_all_brokers_zset'
+MAX_CONCURRENCY_KEY = '_max_concurrency'
+CURRENT_CONCURRENCY_KEY = '_current_concurrency'
 
 WAIT_FOR_EVENT_MAX_SECONDS = 60

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2.1'
+services:
+    redis:
+        image: docker.io/redis:latest
+        command: "--appendonly yes"
+        ports:
+            - 6379:6379
+        volumes:
+            - /tmp/redis-data:/data

--- a/tests/test_memory_brokers.py
+++ b/tests/test_memory_brokers.py
@@ -1,6 +1,9 @@
+from datetime import datetime, timezone
 import pytest
 
 from spinach.brokers.memory import MemoryBroker
+from spinach.job import Job, JobStatus
+from spinach.task import Task
 
 
 @pytest.fixture
@@ -35,3 +38,52 @@ def test_get_queues(broker):
     }
 
     assert broker._get_queue('bar') is queue
+
+
+def test_get_jobs_from_queue_limits_concurrency(broker):
+    task = Task(print, 'foo', 'q1', 10, None, max_concurrency=1)
+    broker.set_concurrency_keys([task])
+    job1 = Job('foo', 'q1', datetime.now(timezone.utc), 10)
+    job2 = Job('foo', 'q1', datetime.now(timezone.utc), 10)
+    broker.enqueue_jobs([job1, job2])
+
+    # Try to get one more than it allows.
+    jobs = broker.get_jobs_from_queue('q1', 2)
+    assert len(jobs) == 1
+
+
+def test_get_jobs_from_queue_re_adds_jobs_if_over_limit(broker):
+    task = Task(print, 'foo', 'q1', 10, None, max_concurrency=1)
+    broker.set_concurrency_keys([task])
+    job1 = Job('foo', 'q1', datetime.now(timezone.utc), 10)
+    job2 = Job('foo', 'q1', datetime.now(timezone.utc), 10)
+    broker.enqueue_jobs([job1, job2])
+
+    # Try to get one more than it allows.
+    [running_job] = broker.get_jobs_from_queue('q1', 2)
+
+    # Pop what's left in the broker's Queue and inspect it.
+    job_json_string = broker._get_queue('q1').get(block=False)
+    queued_job = Job.deserialize(job_json_string)
+    assert queued_job != running_job
+
+
+def test_decrements_concurrency_count_when_job_ends(broker):
+    task = Task(print, 'foo', 'q1', 10, None, max_concurrency=1)
+    broker.set_concurrency_keys([task])
+    job1 = Job('foo', 'q1', datetime.now(timezone.utc), 10)
+    job2 = Job('foo', 'q1', datetime.now(timezone.utc), 10)
+    broker.enqueue_jobs([job1, job2])
+
+    # Start the first job.
+    running_jobs = broker.get_jobs_from_queue('q1', 2)
+    assert 1 == len(running_jobs)
+
+    # No more can start.
+    assert 0 == len(broker.get_jobs_from_queue('q1', 2))
+
+    # Complete the first job.
+    broker.remove_job_from_running(running_jobs[0])
+
+    # Start second job now first has finished.
+    assert 1 == len(broker.get_jobs_from_queue('q1', 2))

--- a/tests/test_redis_brokers.py
+++ b/tests/test_redis_brokers.py
@@ -1,26 +1,58 @@
 from datetime import datetime, timedelta, timezone
+import json
+import operator
+import random
 import time
 from unittest.mock import patch, Mock
 
 import pytest
 
 from spinach.brokers.redis import (
-    RedisBroker, RUNNING_JOBS_KEY, PERIODIC_TASKS_HASH_KEY
+    CURRENT_CONCURRENCY_KEY,
+    MAX_CONCURRENCY_KEY,
+    PERIODIC_TASKS_HASH_KEY,
+    RedisBroker,
+    RUNNING_JOBS_KEY,
 )
 from spinach.job import Job, JobStatus
 from spinach.task import Task
 
 
-@pytest.fixture
-def broker():
+CONCURRENT_TASK_NAME = 'i_am_concurrent'
+CONCURRENT_TASK_MAX_CONCURRENCY = 1
+
+
+def make_broker():
     broker = RedisBroker()
     broker.namespace = 'tests'
     broker.must_stop_periodicity = 0.01
     broker.flush()
+    return broker
+
+
+@pytest.fixture
+def broker():
+    broker = make_broker()
     broker.start()
     yield broker
     broker.stop()
     broker.flush()
+
+
+def set_concurrency_keys(broker, current_concurrency=None):
+    if current_concurrency is None:
+        current_concurrency = 0
+    # Set up dummy concurrency keys for a dummy task.
+    broker._r.hset(
+        broker._to_namespaced(MAX_CONCURRENCY_KEY),
+        CONCURRENT_TASK_NAME,
+        CONCURRENT_TASK_MAX_CONCURRENCY,
+    )
+    broker._r.hset(
+        broker._to_namespaced(CURRENT_CONCURRENCY_KEY),
+        CONCURRENT_TASK_NAME,
+        current_concurrency,
+    )
 
 
 # Fixture to get a second broker
@@ -78,22 +110,194 @@ def test_running_job(broker):
     assert broker.get_jobs_from_queue('foo_queue', 1) == []
 
 
+def test_decrements_concurrency_count_when_job_fails(broker):
+    set_concurrency_keys(broker)
+    job = Job(
+        CONCURRENT_TASK_NAME, 'foo_queue', datetime.now(timezone.utc),
+        max_retries=10,
+    )
+    broker.enqueue_jobs([job])
+    broker.get_jobs_from_queue('foo_queue', 1)
+    current = broker._r.hget(
+        broker._to_namespaced(CURRENT_CONCURRENCY_KEY), CONCURRENT_TASK_NAME
+    )
+    assert current == b'1'
+    job.status = JobStatus.NOT_SET
+    job.retries += 1
+    broker.enqueue_jobs([job], from_failure=True)
+    current = broker._r.hget(
+        broker._to_namespaced(CURRENT_CONCURRENCY_KEY), CONCURRENT_TASK_NAME
+    )
+    assert current == b'0'
+
+
+def test_decrements_concurrency_count_when_job_ends(broker):
+    set_concurrency_keys(broker)
+    job = Job(
+        CONCURRENT_TASK_NAME, 'foo_queue', datetime.now(timezone.utc), 1,
+        # kwargs help with debugging but are not part of the test.
+        task_kwargs=dict(name='job1'),
+    )
+    broker.enqueue_jobs([job])
+    returned_jobs = broker.get_jobs_from_queue('foo_queue', 2)
+    assert len(returned_jobs) == CONCURRENT_TASK_MAX_CONCURRENCY
+    current = broker._r.hget(
+        broker._to_namespaced(CURRENT_CONCURRENCY_KEY), CONCURRENT_TASK_NAME
+    )
+    assert current == b'1'
+    broker.get_jobs_from_queue('foo_queue', 1)
+    job.status = JobStatus.RUNNING
+    broker.remove_job_from_running(job)
+    current = broker._r.hget(
+        broker._to_namespaced(CURRENT_CONCURRENCY_KEY), CONCURRENT_TASK_NAME
+    )
+    assert current == b'0'
+
+
+def test_cant_exceed_max_concurrency(broker):
+    set_concurrency_keys(broker)
+    # An idempotent job is required.
+    job1 = Job(
+        CONCURRENT_TASK_NAME, 'foo_queue', datetime.now(timezone.utc), 1,
+        # kwargs help with debugging but are not part of the test.
+        task_kwargs=dict(name='job1'),
+    )
+    job2 = Job(
+        CONCURRENT_TASK_NAME, 'foo_queue', datetime.now(timezone.utc), 1,
+        task_kwargs=dict(name='job2'),
+    )
+    broker.enqueue_jobs([job1, job2])
+    returned_jobs = broker.get_jobs_from_queue('foo_queue', 2)
+    assert len(returned_jobs) == CONCURRENT_TASK_MAX_CONCURRENCY
+    assert returned_jobs[0].task_kwargs == dict(name='job1')
+
+    # Check the current concurrency was set properly.
+    current = broker._r.hget(
+        broker._to_namespaced(CURRENT_CONCURRENCY_KEY), CONCURRENT_TASK_NAME
+    )
+    assert current == b'1'
+
+    # Make sure job2 was left alone in the queue.
+    queued = broker._r.lpop(broker._to_namespaced('foo_queue'))
+    assert json.loads(queued.decode())['id'] == str(job2.id)
+
+
+def test_get_jobs_from_queue_returns_all_requested(broker):
+    # If a job is not returned because it was over concurrency limits,
+    # make sure the number of jobs requested is filled from other jobs
+    # and that the over-limit one is left alone in the queue.
+    set_concurrency_keys(broker)
+    jobs = [
+        Job(CONCURRENT_TASK_NAME, 'foo_queue', datetime.now(timezone.utc), 1),
+        Job(CONCURRENT_TASK_NAME, 'foo_queue', datetime.now(timezone.utc), 1),
+        Job('foo_task', 'foo_queue', datetime.now(timezone.utc), 1),
+    ]
+    broker.enqueue_jobs(jobs)
+    returned_jobs = broker.get_jobs_from_queue('foo_queue', 2)
+    assert len(returned_jobs) == CONCURRENT_TASK_MAX_CONCURRENCY + 1
+
+
+def test_set_concurrency_keys_sets_new_keys_on_idempotent_tasks(broker):
+    max_c = random.randint(1, 10)
+    tasks = [
+        Task(
+            print, 'foo', 'q1', 10, timedelta(seconds=5),
+            max_concurrency=max_c),
+    ]
+    broker.set_concurrency_keys(tasks)
+    assert int(broker._r.hget(
+        broker._to_namespaced(MAX_CONCURRENCY_KEY),
+        tasks[0].name
+    )) == max_c
+    assert int(broker._r.hget(
+        broker._to_namespaced(CURRENT_CONCURRENCY_KEY),
+        tasks[0].name
+    )) == 0
+
+
+def test_set_concurrency_keys_ignores_tasks_without_concurrency(broker):
+    tasks = [
+        Task(
+            print, 'foo', 'q1', 10, timedelta(seconds=5),
+            max_concurrency=None),
+    ]
+    broker.set_concurrency_keys(tasks)
+    assert broker._r.hget(
+        broker._to_namespaced(MAX_CONCURRENCY_KEY), tasks[0].name
+    ) is None
+
+
+def test_set_concurrency_keys_doesnt_overwrite_existing_concurrency(broker):
+    current_c = random.randint(1, 10)
+    set_concurrency_keys(broker, current_concurrency=current_c)
+    tasks = [
+        Task(
+            print, CONCURRENT_TASK_NAME, 'q1', 10, timedelta(seconds=10),
+            max_concurrency=1
+        ),
+    ]
+    broker.set_concurrency_keys(tasks)
+    assert int(broker._r.hget(
+        broker._to_namespaced(CURRENT_CONCURRENCY_KEY),
+        tasks[0].name
+    )) == current_c
+
+
+def test_set_concurrency_keys_removes_unused_keys_on_deleted_tasks(broker):
+    set_concurrency_keys(broker)
+    # Define different Tasks to CONCURRENT_TASK_NAME with a
+    # max_concurrency setting.
+    task = Task(
+        print, 'foo', 'q1', 10, timedelta(seconds=10), max_concurrency=1
+    )
+    broker.set_concurrency_keys([task])
+    # Check that the testing default concurrency keys were removed.
+    assert broker._r.hexists(
+        broker._to_namespaced(MAX_CONCURRENCY_KEY), CONCURRENT_TASK_NAME
+    ) is False
+    assert broker._r.hexists(
+        broker._to_namespaced(CURRENT_CONCURRENCY_KEY), CONCURRENT_TASK_NAME
+    ) is False
+
+
 def test_enqueue_jobs_from_dead_broker(broker, broker_2):
-    # Enqueue one idempotent job and one non-idempotent job
+    set_concurrency_keys(broker)
+    # Enqueue one idempotent job, one non-idempotent job, and another
+    # that has a max_concurrency.
     job_1 = Job('foo_task', 'foo_queue', datetime.now(timezone.utc), 0)
     job_2 = Job('foo_task', 'foo_queue', datetime.now(timezone.utc), 10)
-    broker.enqueue_jobs([job_1, job_2])
+    job_3 = Job(
+        CONCURRENT_TASK_NAME, 'foo_queue', datetime.now(timezone.utc), 10
+    )
+    broker.enqueue_jobs([job_1, job_2, job_3])
 
     # Simulate broker starting the jobs
     broker.get_jobs_from_queue('foo_queue', 100)
 
-    # Mark broker as dead, should re-enqueue only the idempotent job
-    assert broker_2.enqueue_jobs_from_dead_broker(broker._id) == 1
+    # Check the current_concurrency
+    current = broker._r.hget(
+        broker._to_namespaced(CURRENT_CONCURRENCY_KEY), CONCURRENT_TASK_NAME
+    )
+    assert current == b'1'
+
+    # Mark broker as dead, should re-enqueue only the idempotent jobs.
+    assert broker_2.enqueue_jobs_from_dead_broker(broker._id) == 2
+
+    # Check that the current_concurrency was decremented for job_3.
+    current = broker._r.hget(
+        broker._to_namespaced(CURRENT_CONCURRENCY_KEY), CONCURRENT_TASK_NAME
+    )
+    assert current == b'0'
 
     # Simulate broker 2 getting jobs from the queue
-    job_2.status = JobStatus.RUNNING
-    job_2.retries = 1
-    assert broker_2.get_jobs_from_queue('foo_queue', 100) == [job_2]
+    job_2.status = job_3.status = JobStatus.RUNNING
+    job_2.retries = job_3.retries = 1
+    result = sorted(
+        broker_2.get_jobs_from_queue('foo_queue', 100),
+        key=operator.attrgetter('id')
+    )
+    expected = sorted([job_2, job_3], key=operator.attrgetter('id'))
+    assert result == expected
 
     # Check that a broker can be marked as dead multiple times
     # without duplicating jobs
@@ -146,16 +350,16 @@ def test_old_periodic_tasks(broker):
     broker.register_periodic_tasks(tasks)
     assert broker._number_periodic_tasks == 2
     assert broker._r.hgetall(periodic_tasks_hash_key) == {
-        b'foo': b'{"max_retries": 0, "name": "foo", '
+        b'foo': b'{"max_concurrency": -1, "max_retries": 0, "name": "foo", '
                 b'"periodicity": 5, "queue": "q1"}',
-        b'bar': b'{"max_retries": 0, "name": "bar", '
+        b'bar': b'{"max_concurrency": -1, "max_retries": 0, "name": "bar", '
                 b'"periodicity": 10, "queue": "q1"}'
     }
 
     broker.register_periodic_tasks([tasks[1]])
     assert broker._number_periodic_tasks == 1
     assert broker._r.hgetall(periodic_tasks_hash_key) == {
-        b'bar': b'{"max_retries": 0, "name": "bar", '
+        b'bar': b'{"max_concurrency": -1, "max_retries": 0, "name": "bar", '
                 b'"periodicity": 10, "queue": "q1"}'
     }
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,28 @@
+[tox]
+envlist = py3, pep8
+
+[testenv]
+basepython = python3
+envdir =
+    py3: {toxworkdir}/py3
+    pep8: {toxworkdir}/py3
+usedevelop = True
+whitelist_externals =
+    docker-compose
+    sh
+deps =
+    pytest
+    pytest-cov
+    pytest-threadleak
+    pycodestyle
+    flask
+    django
+
+[testenv:pep8]
+commands =
+    pycodestyle --ignore=E252,W503,W504 spinach tests
+
+[testenv:py3]
+commands =
+    docker-compose -f {toxinidir}/tests/docker-compose.yml up -d
+    sh -c 'pytest tests {posargs}; stat=$?; docker-compose -f {toxinidir}/tests/docker-compose.yml down; exit $stat'


### PR DESCRIPTION
This change adds the `max_concurrency` parameter to `Task`, so that it
can define the maximum number of simultaneous jobs that are running, no
matter how many are queued and waiting to run.
   
Other drive-by changes:

 - Add a tox.ini and docker-compose to start Redis.
   This allows a simple `tox` command to just run all the relevant tests
   and have a temporary Redis start up with which the tests can interact.

 - Amend hacking docs
   - Change pep8 to the recommended pycodestyle invocation
   - Document the `tox` way to test

Fixes https://github.com/NicolasLM/spinach/issues/6
