### PR TITLE
Add Engine.list_queue(),  Broker.list_queue() commands

### DIFF
--- a/examples/queues.py
+++ b/examples/queues.py
@@ -25,3 +25,5 @@ spin.schedule(slow)
 spin.schedule(fast)
 
 spin.start_workers(number=1, queue='high-priority', stop_when_queue_empty=True)
+
+logging.debug(spin.list_queue('low-priority'))

--- a/spinach/brokers/base.py
+++ b/spinach/brokers/base.py
@@ -177,6 +177,10 @@ class Broker(ABC):
         :return: Number of jobs that were moved back to the queue.
         """
 
+    @abstractmethod
+    def list_queue(self, queue):
+        """Non-destructively inspect the given queue."""
+
     def _get_broker_info(self) -> Dict[str, Union[None, str, int]]:
         rv = self._broker_info.copy()
         rv['last_seen_at'] = int(time.time())

--- a/spinach/brokers/memory.py
+++ b/spinach/brokers/memory.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+import json
 from logging import getLogger
 from queue import Queue, Empty
 import sched
@@ -206,3 +207,7 @@ class MemoryBroker(Broker):
                 self._cur_concurrency_keys[job.task_name] -= 1
 
         self._something_happened.set()
+
+    def list_queue(self, queue):
+        """Non-destructively inspect the given queue."""
+        return [json.loads(r) for r in self._get_queue(queue).queue]

--- a/spinach/brokers/redis.py
+++ b/spinach/brokers/redis.py
@@ -68,6 +68,7 @@ class RedisBroker(Broker):
         self._set_concurrency_keys = self._load_script(
             'set_concurrency_keys.lua'
         )
+        self._list_queue = self._load_script('list_queue.lua')
         self._reset()
 
     def _reset(self):
@@ -354,6 +355,13 @@ class RedisBroker(Broker):
             return 0
 
         return next_event_time - now
+
+    def list_queue(self, queue):
+        """Non-destructively inspect the given queue."""
+        result = self._run_script(self._list_queue, self._to_namespaced(queue))
+        queue = [json.loads(r.decode()) for r in result]
+
+        return queue
 
 
 def generate_idempotency_token():

--- a/spinach/brokers/redis_scripts/list_queue.lua
+++ b/spinach/brokers/redis_scripts/list_queue.lua
@@ -1,0 +1,4 @@
+local queue = ARGV[1]
+
+local queue_json = redis.call('lrange', queue, 0, -1)
+return queue_json

--- a/spinach/engine.py
+++ b/spinach/engine.py
@@ -280,3 +280,7 @@ class Engine:
         periodic_tasks = [task for task in self._tasks.tasks.values()
                           if task.periodicity]
         self._broker.register_periodic_tasks(periodic_tasks)
+
+    def list_queue(self, queue):
+        """Non-destructively inspect the given queue."""
+        return self._broker.list_queue(queue)

--- a/tests/test_brokers.py
+++ b/tests/test_brokers.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+import json
 from unittest.mock import patch
 import uuid
 
@@ -137,3 +138,14 @@ def test_periodic_tasks(broker):
     assert r[0][1] == 'foo'
     assert r[1][1] == 'bar'
     assert r[0][0] == r[1][0] - 5
+
+
+def test_list_queue(broker):
+    jobs = [
+        Job('t1', 'q1', get_now(), 0),
+        Job('t2', 'q2', get_now() + timedelta(seconds=10), 0)
+    ]
+    broker.enqueue_jobs(jobs)
+    assert broker.list_queue('q1') == [json.loads(jobs[0].serialize())]
+    assert broker.list_queue('q2') == [json.loads(jobs[1].serialize())]
+    assert broker.list_queue('q3') == []

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -96,3 +96,13 @@ def test_start_workers_blocking():
     spin = Engine(MemoryBroker(), namespace='tests')
     spin.start_workers(number=1, block=True, stop_when_queue_empty=True)
     assert not spin._must_stop.is_set()
+
+
+def test_engine_list_queue():
+    s = Engine(MemoryBroker(), namespace='tests')
+    tasks = Tasks()
+    tasks.add(print, 'foo_task', queue='q1')
+    s.attach_tasks(tasks)
+    tasks.schedule('foo_task')
+    [result] = s.list_queue('q1')
+    assert result['task_name'] == 'foo_task'


### PR DESCRIPTION
This adds a simple interface for inspecting the contents of queues, to facilitate apps making rudimentary decisions based on e.g., queue size, types of jobs in the queue, etc.