### PR TITLE
Signal job failures when recovering dead jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ doc/_build
 
 .coverage
 .pytest_cache
+
+tags

--- a/spinach/brokers/base.py
+++ b/spinach/brokers/base.py
@@ -158,7 +158,9 @@ class Broker(ABC):
         """Return all registered brokers."""
 
     @abstractmethod
-    def enqueue_jobs_from_dead_broker(self, dead_broker_id: uuid.UUID) -> int:
+    def enqueue_jobs_from_dead_broker(
+        self, dead_broker_id: uuid.UUID
+    ) -> Tuple[int, list]:
         """Re-enqueue the jobs that were running on a broker.
 
         Only jobs that can be retired are moved back to the queue, the others

--- a/spinach/brokers/memory.py
+++ b/spinach/brokers/memory.py
@@ -187,9 +187,11 @@ class MemoryBroker(Broker):
         # A memory broker is not connected to any other broker
         return [self._get_broker_info()]
 
-    def enqueue_jobs_from_dead_broker(self, dead_broker_id: uuid.UUID) -> int:
+    def enqueue_jobs_from_dead_broker(
+        self, dead_broker_id: uuid.UUID
+    ) -> Tuple[int, list]:
         # A memory broker cannot be dead
-        return 0
+        return 0, []
 
     def remove_job_from_running(self, job: Job):
         """Remove a job from the list of running ones.

--- a/tests/functional/test_concurrency.py
+++ b/tests/functional/test_concurrency.py
@@ -1,0 +1,31 @@
+import pytest
+import time
+
+from spinach.brokers.memory import MemoryBroker
+from spinach.brokers.redis import RedisBroker
+from spinach.engine import Engine
+
+
+@pytest.fixture(params=[MemoryBroker, RedisBroker])
+def spin(request):
+    broker = request.param
+    spin = Engine(broker(), namespace='tests')
+    yield spin
+
+
+def test_concurrency_limit(spin):
+    count = 0
+
+    @spin.task(name='do_something', max_retries=10, max_concurrency=1)
+    def do_something(index):
+        nonlocal count
+        assert index == count
+        count += 1
+
+    for i in range(0, 5):
+        spin.schedule(do_something, i)
+
+    # Start two workers; test that only one job runs at once as per the
+    # Task definition.
+    spin.start_workers(number=2, block=True, stop_when_queue_empty=True)
+    assert count == 5

--- a/tests/test_brokers.py
+++ b/tests/test_brokers.py
@@ -96,7 +96,7 @@ def test_flush(broker):
 def test_enqueue_jobs_from_dead_broker(broker):
     # Marking a broker that doesn't exist as dead
     broker_id = uuid.UUID('62664577-cf89-4f6a-ab16-4e20ec8fe4c2')
-    assert broker.enqueue_jobs_from_dead_broker(broker_id) == 0
+    assert broker.enqueue_jobs_from_dead_broker(broker_id) == (0, [])
 
 
 def test_get_broker_info(broker):

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
     pytest-cov
     pytest-threadleak
     pycodestyle
+    flake8
     flask
     django
 


### PR DESCRIPTION
The `enqueue_jobs_from_dead_broker.lua` script doesn't re-enqueue jobs
if the max_retries was exceeded. This is very surprising behaviour for
most people, and because the failure handler is not called it means jobs
can be left in an inconsistent state.

This change will make sure that the failure handler is called and the
job moved to the FAILED state.

Drive-by: Add functional tests for concurrency that I forgot to `git
add` previously.

Drive-by: Add tags file to .gitignore

Drive-by: add flake8 to tox venv dependencies so that vscode works
better in that venv

Fixes: https://github.com/NicolasLM/spinach/issues/14