### PR TITLE
Modern Python compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.10"]
 
     services:
       redis:

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     keywords='task queue jobs redis',
 

--- a/spinach/utils.py
+++ b/spinach/utils.py
@@ -74,8 +74,8 @@ def exponential_backoff(attempt: int, cap: int=1200) -> timedelta:
     :arg cap: maximum delay, defaults to 20 minutes
     """
     base = 3
-    temp = min(base * 2 ** attempt, cap)
-    return timedelta(seconds=temp / 2 + random.randint(0, temp / 2))
+    temp = min(base * 2 ** attempt, cap) // 2
+    return timedelta(seconds=temp + random.randint(0, temp))
 
 
 @contextlib.contextmanager

--- a/tests/test_brokers.py
+++ b/tests/test_brokers.py
@@ -67,7 +67,7 @@ def test_wait_for_events_no_future_job(broker):
 
         mock_sh.wait.return_value = True
         broker.wait_for_event()
-        mock_sh.clear.called_once()
+        mock_sh.clear.assert_called_once_with()
 
 
 @pytest.mark.parametrize('delta,timeout', [

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -49,7 +49,7 @@ def test_schedule_at(patch_now):
     now = get_now()
 
     tasks = Tasks()
-    tasks.add(print, 'bar_task')
+    tasks.add(Mock(), 'bar_task')
 
     broker = Mock()
 
@@ -91,8 +91,8 @@ def test_schedule_batch(patch_now):
     now = get_now()
 
     tasks = Tasks()
-    tasks.add(print, 'foo_task')
-    tasks.add(print, 'bar_task')
+    tasks.add(Mock(), 'foo_task')
+    tasks.add(Mock(), 'bar_task')
 
     broker = Mock()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -65,9 +65,6 @@ def test_call_with_retry(_, mock_sleep):
 
 
 def test_exponential_backoff():
-    with pytest.raises(ValueError):
-        utils.exponential_backoff(0)
-
     assert (
         timedelta(seconds=3) <= utils.exponential_backoff(1)
         <= timedelta(seconds=6)


### PR DESCRIPTION
Fix issues preventing Spinach from running correctly on CPython 3.11 / 3.12, and PyPy 3.10.

Fixes: Issue #29