### PR TITLE
chore: update tests to run on node 20

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     services:
       redis:
@@ -18,10 +18,10 @@ jobs:
           - 6379:6379
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,6 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envdir =
     py3: {toxworkdir}/py3
     pep8: {toxworkdir}/py3
 usedevelop = True
-whitelist_externals =
+allowlist_externals =
     docker-compose
 deps =
     pytest


### PR DESCRIPTION
Fix workflows, tox.ini

Drop Python < 3.8 support