### PR TITLE
fix: correct a busted test setup

### DIFF
--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -125,6 +125,7 @@ def test_worker_signals(job):
 
 
 def test_can_accept_job(workers, job):
+    job, _ = job
     assert workers.available_slots == 2
 
     workers.submit_job(job)


### PR DESCRIPTION
This was throwing warnings unrelated to the code under test, which was annoying.  Fix it.

Fixes: Issue #35 