### PR TITLE
RedisBroker: Track non-idempotent jobs as running, too

### DIFF
--- a/spinach/brokers/redis_scripts/get_jobs_from_queue.lua
+++ b/spinach/brokers/redis_scripts/get_jobs_from_queue.lua
@@ -30,13 +30,11 @@ repeat
         job["status"] = job_status_running
         local job_json = cjson.encode(job)
 
-        if job["max_retries"] > 0 then
-            -- job is idempotent, must track if it's running
-            redis.call('hset', running_jobs_key, job["id"], job_json)
-            -- If tracking concurrency, bump the current value.
-            if max_concurrency ~= -1 then
-                redis.call('hincrby', current_concurrency_key, job['task_name'], 1)
-            end
+        -- track the running job
+        redis.call('hset', running_jobs_key, job["id"], job_json)
+        -- If tracking concurrency, bump the current value.
+        if max_concurrency ~= -1 then
+            redis.call('hincrby', current_concurrency_key, job['task_name'], 1)
         end
 
         jobs[i] = job_json


### PR DESCRIPTION
Push running-job markers down into the Redis for all jobs, and move the logic for re-enqueueing jobs from dead brokers into the script itself.  Non-idempotent jobs running on a dead broker are still NOT re-enqueued.

This should cause non-idempotent jobs to no longer run "invisibly" on a Redis broker, as well as causing dead brokers to signal any non-idempotent jobs that were running on them as failed.

Fixes: Issue #18