### PR TITLE
fix: only increment the `current_concurrency` counter if the job has `max_concurrency` set

### DIFF
--- a/spinach/brokers/redis_scripts/get_jobs_from_queue.lua
+++ b/spinach/brokers/redis_scripts/get_jobs_from_queue.lua
@@ -33,7 +33,7 @@ repeat
         -- track the running job
         redis.call('hset', running_jobs_key, job["id"], job_json)
         -- If tracking concurrency, bump the current value.
-        if max_concurrency ~= -1 then
+        if max_concurrency ~= nil and max_concurrency ~= -1 then
             redis.call('hincrby', current_concurrency_key, job['task_name'], 1)
         end
 


### PR DESCRIPTION
Seems to have been a small oversight when popping idempotent jobs from the queue on Redis.

Fixes: Issue #15