### PR TITLE
fix: RedisBroker: Remove non-idempotent jobs from running, too

### DIFF
--- a/spinach/brokers/redis.py
+++ b/spinach/brokers/redis.py
@@ -226,15 +226,13 @@ class RedisBroker(Broker):
         return jobs
 
     def remove_job_from_running(self, job: Job):
-        if job.max_retries > 0:
-            self._run_script(
-                self._remove_job_from_running,
-                self._to_namespaced(RUNNING_JOBS_KEY.format(self._id)),
-                self._to_namespaced(MAX_CONCURRENCY_KEY),
-                self._to_namespaced(CURRENT_CONCURRENCY_KEY),
-                job.serialize(),
-            )
-
+        self._run_script(
+            self._remove_job_from_running,
+            self._to_namespaced(RUNNING_JOBS_KEY.format(self._id)),
+            self._to_namespaced(MAX_CONCURRENCY_KEY),
+            self._to_namespaced(CURRENT_CONCURRENCY_KEY),
+            job.serialize(),
+        )
         self._something_happened.set()
 
     def _subscriber_func(self):

--- a/tests/test_redis_brokers.py
+++ b/tests/test_redis_brokers.py
@@ -86,6 +86,7 @@ def test_running_job(broker):
     )
     # Try to remove it, even if it doesn't exist in running
     broker.remove_job_from_running(job)
+    assert broker._r.hget(running_jobs_key, str(job.id)) is None
 
     # Idempotent job - get from queue
     job = Job('foo_task', 'foo_queue', datetime.now(timezone.utc), 10)


### PR DESCRIPTION
Adds a test that the running job is actually gone.

Fixes: Issue #45