### PR TITLE
feat: add `periodicity_start` parameter to Tasks

### DIFF
--- a/doc/user/tasks.rst
+++ b/doc/user/tasks.rst
@@ -125,13 +125,22 @@ Tasks marked as periodic get automatically scheduled. To run a task every 5 seco
 .. literalinclude:: ../../examples/periodic.py
 
 Periodic tasks get scheduled by the workers themselves, there is no need to run an additional
-process only for that. Of course having multiple workers on multiple machine is fine and will not
-result in duplicated tasks.
+process only for that. Having multiple workers on multiple machine is fine and will not result in
+duplicated tasks.
 
-Periodic tasks run at most every `period`. If the system scheduling periodic tasks gets delayed,
-nothing compensates for the time lost. This has the added benefit of periodic tasks not being
-scheduled if all the workers are down for a prolonged amount of time. When they get back online,
-workers won't have a storm of periodic tasks to execute.
+An optional `periodicity_start` parameter may be passed, that will "snap" the initial task start
+to a given value, e.g.,::
+
+    @tasks.task(name='snapped', periodicity=timedelta(hours=1), periodicity_start=timedelta(minutes=15))
+    def foo(a, b):
+        pass
+
+This will run the task hourly, starting at the next 15-minute boundary (0, 15, 30, 45).
+
+Periodic tasks run at most every `periodicity`. If the system scheduling periodic tasks gets
+delayed, nothing compensates for the time lost. This has the added benefit of periodic tasks not
+being scheduled if all the workers are down for a prolonged amount of time. When they get back
+online, workers won't have a storm of periodic tasks to execute.
 
 Tasks Registry
 --------------

--- a/spinach/brokers/base.py
+++ b/spinach/brokers/base.py
@@ -1,3 +1,4 @@
+import math
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from logging import getLogger
@@ -183,6 +184,11 @@ class Broker(ABC):
         rv = self._broker_info.copy()
         rv['last_seen_at'] = int(time.time())
         return rv
+
+    @classmethod
+    def start_at(cls) -> datetime:
+        now = math.ceil(datetime.now(timezone.utc).timestamp())
+        return datetime.fromtimestamp(now, tz=timezone.utc)
 
     def __repr__(self):
         return '<{}: {}>'.format(self.__class__.__name__, self._id)

--- a/spinach/brokers/memory.py
+++ b/spinach/brokers/memory.py
@@ -1,4 +1,3 @@
-from datetime import datetime, timezone
 from logging import getLogger
 from queue import Queue, Empty
 import sched
@@ -96,7 +95,7 @@ class MemoryBroker(Broker):
             )
 
     def _schedule_periodic_task(self, task: Task):
-        at = datetime.now(timezone.utc)
+        at = self.start_at()
         job = Job(task.name, task.queue, at, task.max_retries)
         self.enqueue_jobs([job])
         self._scheduler.enter(

--- a/spinach/brokers/memory.py
+++ b/spinach/brokers/memory.py
@@ -88,7 +88,7 @@ class MemoryBroker(Broker):
         """Register tasks that need to be scheduled periodically."""
         for task in tasks:
             self._scheduler.enter(
-                int(task.periodicity.total_seconds()),
+                int(task.periodicity.total_seconds()) + task.periodicity_start,
                 0,
                 self._schedule_periodic_task,
                 argument=(task,)

--- a/spinach/brokers/redis.py
+++ b/spinach/brokers/redis.py
@@ -1,7 +1,5 @@
-from datetime import datetime, timezone
 import json
 from logging import getLogger
-import math
 from os import path
 import socket
 import threading
@@ -150,7 +148,7 @@ class RedisBroker(Broker):
             self.namespace,
             self._to_namespaced(FUTURE_JOBS_KEY),
             self._to_namespaced(NOTIFICATIONS_KEY),
-            math.ceil(datetime.now(timezone.utc).timestamp()),
+            self.start_at().timestamp(),
             JobStatus.QUEUED.value,
             self._to_namespaced(PERIODIC_TASKS_HASH_KEY),
             self._to_namespaced(PERIODIC_TASKS_QUEUE_KEY),
@@ -316,7 +314,7 @@ class RedisBroker(Broker):
         self._number_periodic_tasks = len(_tasks)
         self._run_script(
             self._register_periodic_tasks,
-            math.ceil(datetime.now(timezone.utc).timestamp()),
+            self.start_at().timestamp(),
             self._to_namespaced(PERIODIC_TASKS_HASH_KEY),
             self._to_namespaced(PERIODIC_TASKS_QUEUE_KEY),
             *_tasks
@@ -361,7 +359,7 @@ class RedisBroker(Broker):
         if not rv:
             return None
 
-        now = datetime.now(timezone.utc).timestamp()
+        now = self.start_at()
         next_event_time = rv[0][1]
         if next_event_time < now:
             return 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,6 @@ def patch_now(monkeypatch):
             return datetime.fromtimestamp(*args, **kwargs)
 
     monkeypatch.setattr('spinach.brokers.base.datetime', MyDatetime)
-    monkeypatch.setattr('spinach.brokers.redis.datetime', MyDatetime)
     monkeypatch.setattr('spinach.job.datetime', MyDatetime)
     monkeypatch.setattr('spinach.engine.datetime', MyDatetime)
     monkeypatch.setattr('spinach.task.datetime', MyDatetime)

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,9 +1,9 @@
-version: '2.1'
+---
 services:
     redis:
         image: docker.io/redis:latest
         command: "--appendonly yes"
         ports:
-            - 6379:6379
+            - "6379:6379"
         volumes:
             - /tmp/redis-data:/data

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -39,9 +39,9 @@ def test_task_eq(task):
 
 def test_task_repr(task):
     task_repr = repr(task)
-    expected = 'Task({}, {}, {}, {}, {}, {})'.format(
+    expected = 'Task({}, {}, {}, {}, {}, {}, {})'.format(
         task.func, task.name, task.queue, task.max_retries,
-        task.periodicity, task.max_concurrency,
+        task.periodicity, task.periodicity_start, task.max_concurrency,
     )
     assert task_repr == expected
 
@@ -67,16 +67,16 @@ def test_tasks_add(task):
 def test_task_serialize(task):
     expected = (
         '{"max_concurrency": -1, "max_retries": 0, '
-        '"name": "write_to_stdout", '
-        '"periodicity": null, "queue": "foo_queue"}'
+        '"name": "write_to_stdout", "periodicity": null, '
+        '"periodicity_start": 0, "queue": "foo_queue"}'
     )
     assert task.serialize() == expected
 
     task.periodicity = timedelta(minutes=5)
     expected = (
         '{"max_concurrency": -1, "max_retries": 0, '
-        '"name": "write_to_stdout", '
-        '"periodicity": 300, "queue": "foo_queue"}'
+        '"name": "write_to_stdout", "periodicity": 300, '
+        '"periodicity_start": 0, "queue": "foo_queue"}'
     )
     assert task.serialize() == expected
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envdir =
     pep8: {toxworkdir}/py3
 usedevelop = True
 allowlist_externals =
-    docker-compose
+    docker
 deps =
     pytest
     pytest-cov
@@ -23,6 +23,6 @@ commands =
     pycodestyle --ignore=E252,W503,W504 spinach tests
 
 [testenv:py3]
-commands_pre = docker-compose -f {toxinidir}/tests/docker-compose.yml up -d
+commands_pre = docker compose -f {toxinidir}/tests/docker-compose.yml up -d
 commands = pytest tests {posargs}
-commands_post = docker-compose -f {toxinidir}/tests/docker-compose.yml down
+commands_post = docker compose -f {toxinidir}/tests/docker-compose.yml down


### PR DESCRIPTION
Adds a new, optional, argument to task creation, `periodcity_start`, which gives Task authors finer control over scheduling of periodic tasks.  Specifically, it allows Tasks to pin their start time to a defined wall-clock time, albeit on a best-effort basis, like all Tasks.

Fixes: Issue #48